### PR TITLE
Fixed swift platform generated constants file.

### DIFF
--- a/lib/localio/templates/swift_constant_localizable.erb
+++ b/lib/localio/templates/swift_constant_localizable.erb
@@ -6,6 +6,8 @@ GENERATED - DO NOT MODIFY - use localio instead.
 Created by localio
 */
 
+import Foundation
+
 <% @segments.each do |term| %>
 let <%= term.key %>: String = { return NSLocalizedString("<%= term.translation %>", comment: "") }()<%
 end %>


### PR DESCRIPTION
This should fix the compilation errors you get (in my case, tested on Xcode 6.4 & iOS 8) with the generated "LocalizableConstants.swift".