### PR TITLE
Add token options for google drive

### DIFF
--- a/lib/localio/processors/google_drive_processor.rb
+++ b/lib/localio/processors/google_drive_processor.rb
@@ -43,7 +43,12 @@ class GoogleDriveProcessor
 
       access_token = nil
 
-      if config.has? :refresh_token
+      if options.has_key?(:client_token)
+        puts 'Refreshing auth token...'
+        auth.refresh_token = options[:client_token]
+        auth.refresh!
+        access_token = auth.access_token
+      elsif config.has? :refresh_token
         puts 'Refreshing auth token...'
         auth.refresh_token = config.get :refresh_token
         auth.refresh!
@@ -56,9 +61,12 @@ class GoogleDriveProcessor
         access_token = auth.access_token
       end
 
+    if !options.has_key?(:client_token)
+      puts 'Store auth data...'
       config.store :refresh_token, auth.refresh_token
       config.store :access_token, auth.access_token
       config.persist
+    end
 
       # Creates a session
       session = GoogleDrive.login_with_oauth(access_token)

--- a/lib/localio/version.rb
+++ b/lib/localio/version.rb
@@ -1,3 +1,3 @@
 module Localio
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
I add the persistent refresh token as option for google drive. With this option no storing is necessary in .localio.yml.

```
source :google_drive,
       :spreadsheet => 'Tagesschau | Localization',
       :client_id => 'XXXXXXXX-XXXXXXX.apps.googleusercontent.com',
       :client_secret => 'XXXXX',
       :client_token => 'XXXXX'
```