### PR TITLE
Issue 20: add sheet_index option for xlsx and xls

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,27 +159,33 @@ export CLIENT_SECRET="your_client_secret"
 ##### XLS
 
 `source :xls` will use a local XLS file. In the parameter's hash you should specify a `:path`.
+You may specify a `sheet` parameter, otherwise the first sheet will be used.
 
 Option                      | Description
 ----------------------------|-------------------------------------------------------------------------
 `:path`                     | (Req.) Path for your XLS file.
+`:sheet`                    | (Optional) Index number (starting with 0) or name of the sheet w/ the data
 
 ````ruby
 source :xls,
-       :path => 'YourExcelFileWithTranslations.xls'
+       :path => 'YourExcelFileWithTranslations.xls',
+       :sheet => 'Master Translation Data'
 ````
 
 ##### XLSX
 
 `source :xlsx` will use a local XLSX file. In the parameter's hash you should specify a `:path`.
+You may specify a `sheet` parameter, otherwise the first sheet will be used.
 
 Option                      | Description
 ----------------------------|-------------------------------------------------------------------------
 `:path`                     | (Req.) Path for your XLSX file.
+`:sheet`                    | (Optional) Index number (starting with 0) or name of the sheet w/ the data
 
 ````ruby
 source :xlsx,
-       :path => 'YourExcelFileWithTranslations.xlsx'
+       :path => 'YourExcelFileWithTranslations.xlsx',
+       :sheet => 'Master Translation Data'
 ````
 
 ##### CSV

--- a/lib/localio/processors/xls_processor.rb
+++ b/lib/localio/processors/xls_processor.rb
@@ -9,6 +9,8 @@ class XlsProcessor
     path = options[:path]
     raise ArgumentError, ':path attribute is missing from the source, and it is required for xls spreadsheets' if path.nil?
 
+    sheet = options[:sheet] || 0
+
     override_default = nil
     override_default = platform_options[:override_default] unless platform_options.nil? or platform_options[:override_default].nil?
 
@@ -16,9 +18,8 @@ class XlsProcessor
 
     book = Spreadsheet.open path
 
-    # TODO we could pass a :page_index in the options hash and get that worksheet instead, defaulting to zero?
-    worksheet = book.worksheet 0
-    raise 'Unable to retrieve the first worksheet from the spreadsheet. Are there any pages?' if worksheet.nil?
+    worksheet = book.worksheet(sheet)
+    raise "Unable to retrieve the specified worksheet from the spreadsheet. Are there any pages?" if worksheet.nil?
 
     # At this point we have the worksheet, so we want to store all the key / values
     first_valid_row_index = nil

--- a/lib/localio/processors/xlsx_processor.rb
+++ b/lib/localio/processors/xlsx_processor.rb
@@ -9,14 +9,20 @@ class XlsxProcessor
     path = options[:path]
     raise ArgumentError, ':path attribute is missing from the source, and it is required for xlsx spreadsheets' if path.nil?
 
+    sheet = options[:sheet]
+
     override_default = nil
     override_default = platform_options[:override_default] unless platform_options.nil? or platform_options[:override_default].nil?
 
     book = SimpleXlsxReader.open path
 
-    # TODO we could pass a :page_index in the options hash and get that worksheet instead, defaulting to zero?
-    worksheet = book.sheets.first
-    raise 'Unable to retrieve the first worksheet from the spreadsheet. Are there any pages?' if worksheet.nil?
+    worksheet = if sheet.is_a? Integer
+                  book.sheets[sheet]
+                elsif sheet.is_a? String
+                  book.sheets.detect { |s| s.name == sheet }
+                end
+
+    raise 'Unable to retrieve the specified worksheet from the spreadsheet. Are there any pages?' if worksheet.nil?
 
     # At this point we have the worksheet, so we want to store all the key / values
     first_valid_row_index = nil


### PR DESCRIPTION
This PR adds the ability to specify which sheet you would like to use in your XLSX or XLS sources by passing a `sheet` parameter in the `source` section of the Locfile. This parameter can either be a numerical index (starting with 0), or a string representing the name of the sheet. 