### PR TITLE
 Added output_filename parameter to ios, swift and android

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ platform :ios
 
 output_path 'my_output_path/'
 
+output_filename 'custom.strings'
+
 source :xlsx,
        :path => 'my_translations.xlsx'
 ````
@@ -60,6 +62,7 @@ Option                      | Description                                       
 `platform`                  | (Req.) Target platform for the localizable files.                | `nil`
 `source`                    | (Req.) Information on where to find the spreadsheet w/ the info  | `nil`
 `output_path`               | (Req.) Target directory for the localizables.                    | `out/`
+`output_filename`           | Target file name        for the localizables.                    | nil
 `formatting`                | The formatter that will be used for key processing.              | `smart`
 `except`                    | Filter applied to the keys, process all except the matches.      | `nil`
 `only`                      | Filter applied to the keys, only process the matches.            | `nil`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Option                      | Description                                       
 `platform`                  | (Req.) Target platform for the localizable files.                | `nil`
 `source`                    | (Req.) Information on where to find the spreadsheet w/ the info  | `nil`
 `output_path`               | (Req.) Target directory for the localizables.                    | `out/`
-`output_filename`           | Target file name        for the localizables.                    | nil
+`output_filename`           | Target file name for the localizables (android, ios, swift only) | nil
 `formatting`                | The formatter that will be used for key processing.              | `smart`
 `except`                    | Filter applied to the keys, process all except the matches.      | `nil`
 `only`                      | Filter applied to the keys, only process the matches.            | `nil`

--- a/lib/localio.rb
+++ b/lib/localio.rb
@@ -54,6 +54,7 @@ module Localio
                             @localizables[:languages],
                             @localizables[:segments],
                             @configuration.output_path,
+                            @configuration.output_filename,
                             @configuration.formatting,
                             @configuration.platform_options
     puts 'Done!'.green

--- a/lib/localio/localizable_writer.rb
+++ b/lib/localio/localizable_writer.rb
@@ -7,14 +7,14 @@ require 'localio/writers/java_properties_writer'
 require 'localio/writers/resx_writer'
 
 module LocalizableWriter
-  def self.write(platform, languages, terms, path, formatter, options)
+  def self.write(platform, languages, terms, path, filename, formatter, options)
     case platform
       when :android
-        AndroidWriter.write languages, terms, path, formatter, options
+        AndroidWriter.write languages, terms, path, filename, formatter, options
       when :ios
-        IosWriter.write languages, terms, path, formatter, options
+        IosWriter.write languages, terms, path, filename, formatter, options
       when :swift
-        SwiftWriter.write languages, terms, path, formatter, options
+        SwiftWriter.write languages, terms, path, filename, formatter, options
       when :json
         JsonWriter.write languages, terms, path, formatter, options
       when :rails

--- a/lib/localio/locfile.rb
+++ b/lib/localio/locfile.rb
@@ -11,6 +11,9 @@ class Locfile
   # Specifies the filesystem path where the generated files will be
   dsl_accessor :output_path
 
+  # Specifies the file name of the generated files
+  dsl_accessor :output_filename
+  
   # Specifies the format for the keys in the localizable file
   #
   # :smart - choose the formatting depending on the platform's best practices. This is the best option for multiplatform apps.
@@ -35,6 +38,7 @@ class Locfile
     @source_path = nil
     @source_options = nil
     @output_path = './out/'
+    @output_filename = nil
     @formatting = :smart
   end
 

--- a/lib/localio/version.rb
+++ b/lib/localio/version.rb
@@ -1,3 +1,3 @@
 module Localio
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/lib/localio/writers/android_writer.rb
+++ b/lib/localio/writers/android_writer.rb
@@ -5,7 +5,7 @@ require 'localio/formatter'
 require 'nokogiri'
 
 class AndroidWriter
-  def self.write(languages, terms, path, formatter, options)
+  def self.write(languages, terms, path, filename, formatter, options)
     puts 'Writing Android translations...'
     default_language = options[:default_language]
 

--- a/lib/localio/writers/android_writer.rb
+++ b/lib/localio/writers/android_writer.rb
@@ -13,6 +13,8 @@ class AndroidWriter
       output_path = File.join(path,"values-#{lang}/")
       output_path = File.join(path,'values/') if default_language == lang
 
+      output_filename = filename != nil ? filename : 'strings.xml'
+
       # We have now to iterate all the terms for the current language, extract them, and store them into a new array
 
       segments = SegmentsListHolder.new lang
@@ -24,7 +26,7 @@ class AndroidWriter
         segments.segments << segment
       end
 
-      TemplateHandler.process_template 'android_localizable.erb', output_path, 'strings.xml', segments
+      TemplateHandler.process_template 'android_localizable.erb', output_path, output_filename, segments
       puts " > #{lang.yellow}"
     end
 

--- a/lib/localio/writers/ios_writer.rb
+++ b/lib/localio/writers/ios_writer.rb
@@ -4,7 +4,7 @@ require 'localio/segment'
 require 'localio/formatter'
 
 class IosWriter
-  def self.write(languages, terms, path, formatter, options)
+  def self.write(languages, terms, path, filename, formatter, options)
     puts 'Writing iOS translations...'
     create_constants = options[:create_constants].nil? ? true : options[:create_constants]
 
@@ -12,6 +12,8 @@ class IosWriter
     languages.keys.each do |lang|
       output_path = File.join(path, "#{lang}.lproj/")
 
+      output_filename = filename != nil ? filename : 'Localizable.strings'
+      
       # We have now to iterate all the terms for the current language, extract them, and store them into a new array
 
       segments = SegmentsListHolder.new lang
@@ -31,7 +33,7 @@ class IosWriter
         end
       end
 
-      TemplateHandler.process_template 'ios_localizable.erb', output_path, 'Localizable.strings', segments
+      TemplateHandler.process_template 'ios_localizable.erb', output_path, output_filename, segments
       puts " > #{lang.yellow}"
     end
 

--- a/lib/localio/writers/swift_writer.rb
+++ b/lib/localio/writers/swift_writer.rb
@@ -12,6 +12,8 @@ class SwiftWriter
     languages.keys.each do |lang|
       output_path = File.join(path, "#{lang}.lproj/")
 
+      output_filename = filename != nil ? filename : 'Localizable.strings'
+
       # We have now to iterate all the terms for the current language, extract them, and store them into a new array
 
       segments = SegmentsListHolder.new lang
@@ -31,7 +33,7 @@ class SwiftWriter
         end
       end
 
-      TemplateHandler.process_template 'ios_localizable.erb', output_path, 'Localizable.strings', segments
+      TemplateHandler.process_template 'ios_localizable.erb', output_path, output_filename, segments
       puts " > #{lang.yellow}"
     end
 

--- a/localio.gemspec
+++ b/localio.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency "micro-optparse", "~> 1.2"
-  spec.add_dependency "google_drive", "~> 1.0"
+  spec.add_dependency "google_drive", "~> 1.0.6"
   spec.add_dependency "spreadsheet", "~> 1.0"
   spec.add_dependency "simple_xlsx_reader", "~> 1.0"
   spec.add_dependency "nokogiri", "~> 1.6"


### PR DESCRIPTION
Hi,
first of all thanks for localio, which has made our lives much easier :)
Last year I forked your repo to support multiple output paths; this is necessary because we're working on a multi-target project, that uses different sources; also, more than one spreadsheet is used for each target. 
I simply added an optional output_filename parameter; when absent, localio falls back to defaults, so it should be a non-breaking change.
Cheers,
Davide
