### PR TITLE
Add avoid_lang_downcase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Option                      | Description                                       
 
 #### Extra platform parameters
 
+
+#####  `avoid_lang_downcase`
+
+By default, language codes are downcased. We can set `:avoid_lang_downcase => true` to avoid this behavior.
+
 ##### iOS - :ios, :swift
 
 We can opt-out from the constants/macros. We will simple need to add `:create_constants => false`. By default, if omitted, the constants will be always created. It's a good practice to have a compile-time check of the existence of your keys; but if you don't like it it's fine.

--- a/lib/localio/processor.rb
+++ b/lib/localio/processor.rb
@@ -5,6 +5,7 @@ require 'localio/processors/csv_processor'
 
 module Processor
   def self.load_localizables(platform_options, service, options)
+    puts "Service: #{service}"
     case service
       when :google_drive
         GoogleDriveProcessor.load_localizables platform_options, options

--- a/lib/localio/processors/csv_processor.rb
+++ b/lib/localio/processors/csv_processor.rb
@@ -36,8 +36,17 @@ class CsvProcessor
     for column in 1..csv_file[first_valid_row_index].count-1
       col_all = csv_file[first_valid_row_index][column].to_s
       col_all.each_line(' ') do |col_text|
-        default_language = col_text.downcase.gsub('*', '') if col_text.include? '*'
-        languages.store col_text.downcase.gsub('*', ''), column unless col_text.to_s == ''
+        default_language = col_text.gsub('*', '') if col_text.include? '*'
+        lang = col_text.gsub('*', '')
+
+        unless platform_options[:avoid_lang_downcase]
+          default_language = default_language.downcase
+          lang = lang.downcase
+         end
+
+        unless col_text.to_s == ''
+          languages.store lang, column
+        end
       end
     end
 

--- a/lib/localio/processors/google_drive_processor.rb
+++ b/lib/localio/processors/google_drive_processor.rb
@@ -114,8 +114,17 @@ class GoogleDriveProcessor
     for column in 2..worksheet.max_cols
       col_all = worksheet[first_valid_row_index, column]
       col_all.each_line(' ') do |col_text|
-        default_language = col_text.downcase.gsub('*', '') if col_text.include? '*'
-        languages.store col_text.downcase.gsub('*', ''), column unless col_text.to_s == ''
+        default_language = col_text.gsub('*', '') if col_text.include? '*'
+        lang = col_text.gsub('*', '')
+
+        unless platform_options[:avoid_lang_downcase]
+          default_language = default_language.downcase
+          lang = lang.downcase
+         end
+
+        unless col_text.to_s == ''
+          languages.store lang, column
+        end
       end
     end
 

--- a/lib/localio/processors/xls_processor.rb
+++ b/lib/localio/processors/xls_processor.rb
@@ -40,8 +40,17 @@ class XlsProcessor
     for column in 1..worksheet.column_count
       col_all = worksheet[first_valid_row_index, column].to_s
       col_all.each_line(' ') do |col_text|
-        default_language = col_text.downcase.gsub('*','') if col_text.include? '*'
-        languages.store col_text.downcase.gsub('*',''), column unless col_text.to_s == ''
+        default_language = col_text.gsub('*', '') if col_text.include? '*'
+        lang = col_text.gsub('*', '')
+
+        unless platform_options[:avoid_lang_downcase]
+          default_language = default_language.downcase
+          lang = lang.downcase
+        end
+
+        unless col_text.to_s == ''
+          languages.store lang, column
+        end
       end
     end
 

--- a/lib/localio/processors/xlsx_processor.rb
+++ b/lib/localio/processors/xlsx_processor.rb
@@ -43,8 +43,17 @@ class XlsxProcessor
     for column in 1..worksheet.rows[first_valid_row_index].count-1
       col_all = worksheet.rows[first_valid_row_index][column].to_s
       col_all.each_line(' ') do |col_text|
-        default_language = col_text.downcase.gsub('*','') if col_text.include? '*'
-        languages.store col_text.downcase.gsub('*',''), column unless col_text.to_s == ''
+        default_language = col_text.gsub('*', '') if col_text.include? '*'
+        lang = col_text.gsub('*', '')
+
+        unless platform_options[:avoid_lang_downcase]
+          default_language = default_language.downcase
+          lang = lang.downcase
+         end
+
+        unless col_text.to_s == ''
+          languages.store lang, column
+        end
       end
     end
     


### PR DESCRIPTION
Add the `avoid_lang_downcase` option, wich you can set to `true` if you want to avoid downcase on the language code.

In our specific case, we need to generate Java `language_*.properties` files, which are case sensitive with lang/country codes. Ex: `language_gl_ES.properties` vs `language_gl_es.properties`