### PR TITLE
Added custom changes to writers and templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/version_tmp
 tmp
 .idea/
 testing/
+.vscode/launch.json

--- a/lib/localio/template_handler.rb
+++ b/lib/localio/template_handler.rb
@@ -6,11 +6,13 @@ class TemplateHandler
     full_template_path = File.join(File.dirname(File.expand_path(__FILE__)), "templates/#{template_name}")
     input_file = File.open(full_template_path, 'rb')
     template = input_file.read
+   
     input_file.close
     renderer = ERB.new(template)
     output = renderer.result(segments.get_binding)
     output_file = File.new(generated_file_name, 'w')
-    output_file.write(output)
+    output_replace = output.gsub(",}", "}")
+    output_file.write(output_replace)
     output_file.close
 
     destination_path = File.join(target_directory, generated_file_name)

--- a/lib/localio/templates/android_localizable.erb
+++ b/lib/localio/templates/android_localizable.erb
@@ -1,11 +1,23 @@
 <!-- Localizable created with localio. DO NOT MODIFY. -->
 <resources>
 <%
+node_keys =[]
 @segments.each do |term|
      if term.is_comment? %>
   <!-- <%= term.translation %> -->
-<% else %>  <string name="<%= term.key %>"><%= term.translation %></string>
-<%   end
+<% else 
+    if term.key == '[init-node]' or term.key == '[end-node]'
+          node_keys << term.translation if term.key == '[init-node]'
+          node_keys.pop if term.key == '[end-node]'
+      else
+        if node_keys.length() > 0
+            key_join = node_keys.join("_")+"_"+term.key
+        else
+            key_join = term.key
+        end
+%>  <string name="<%= key_join %>"><%= term.translation %></string>
+<%    end 
+    end
   end
 %>
 </resources>

--- a/lib/localio/templates/ios_constant_localizable.erb
+++ b/lib/localio/templates/ios_constant_localizable.erb
@@ -6,6 +6,20 @@ GENERATED - DO NOT MODIFY - use localio instead.
 Created by localio.
 */
 
-<% @segments.each do |term| %>
-#define		<%= term.key %>		NSLocalizedString(@"<%= term.translation %>",nil)<%
+<% 
+node_keys = []
+@segments.each do |term|
+    if term.key == '[init-node]' or term.key == '[end-node]'
+        node_keys << term.translation if term.key == '[init-node]'
+        node_keys.pop if term.key == '[end-node]'
+    else
+        if node_keys.length() >0
+            key_join = node_keys.join("_").capitalize+"_"+term.key.downcase
+        else
+            key_join = term.key
+        end
+%>
+#define		kLocale<%= key_join %>		NSLocalizedString(@"_<%= key_join %>",nil)
+<%
+    end
 end %>

--- a/lib/localio/templates/ios_localizable.erb
+++ b/lib/localio/templates/ios_localizable.erb
@@ -6,12 +6,27 @@ GENERATED - DO NOT MODIFY - use the localio gem instead.
 Created by localio.
 */
 
-<% @segments.each do |term| %>
-<%
-  if term.is_comment?
+<% 
+  node_keys = []
+  @segments.each do |term| 
+    if term.is_comment?
 %>
-// <%= term.translation %>
-<% else %>"<%= term.key %>" = "<%= term.translation %>";<%
+  // <%= term.translation %>
+<% 
+    else 
+      if term.key == '[init-node]' or term.key == '[end-node]'
+          node_keys << term.translation if term.key == '[init-node]'
+          node_keys.pop if term.key == '[end-node]'
+      else
+        if node_keys.length() > 0
+            key_join = node_keys.join("_").capitalize+"_"+term.key.downcase
+        else
+            key_join = term.key
+        end
+%>
+  "_<%= key_join %>" = "<%= term.translation %>";
+<%
+      end
     end
   end
 %>

--- a/lib/localio/templates/java_properties_localizable.erb
+++ b/lib/localio/templates/java_properties_localizable.erb
@@ -1,10 +1,24 @@
 # Localizable created with localio. DO NOT MODIFY.
 #
 # Language: <%= @language %>
-<% @segments.each do |term|
+<%
+node_keys = []
+@segments.each do |term|
 	if term.is_comment? %>
 # <%= term.translation %>
-<% 	else %><%= term.key %>=<%= term.translation %>
+<% 
+else
+    if term.key == '[init-node]' or term.key == '[end-node]'
+        node_keys << term.translation if term.key == '[init-node]'
+        node_keys.pop if term.key == '[end-node]'
+    else
+      if node_keys.length() > 0
+        key_join = node_keys.join("_")+"_"+term.key
+      else
+        key_join = term.key
+      end
+%><%= key_join %>=<%= term.translation %>
 <%  end
   end
+end
 %>

--- a/lib/localio/templates/json_localizable.erb
+++ b/lib/localio/templates/json_localizable.erb
@@ -4,12 +4,13 @@
         "language": "<%= @language %>"
     },
     "translations": {
-<%   @segments.each do |term|
+<%   @segments.each.with_index do |term, index|
          term_value = term.translation
          term_key = term.key
-
-         term_key = '___comment___' if term.is_comment?
-%>      "<%= term_key %>": "<%= term_value %>"<% unless term == @segments.last %>,<% end %>
-<%     end %>
+         count_to_string = index.to_s
+         term_key = '___comment_'+count_to_string+'___' if term.is_comment?
+        if term.key == '[init-node]'%>  
+    "<%= term_value %>": {<% elsif term.key == '[end-node]'%>}<% unless term == @segments.last %>,<% end %><% else %>
+    "<%= term_key %>": "<%= term_value %>"<% unless term == @segments.last %>,<% end %><% end end %>
     }
 }

--- a/lib/localio/templates/rails_localizable.erb
+++ b/lib/localio/templates/rails_localizable.erb
@@ -4,10 +4,22 @@
 
 <%= @language %>:
 <%
+node_keys = []
 @segments.each do |term|
-     if term.is_comment? %>
+    if term.is_comment? %>
 # <%= term.translation %>
-<% else %>  <%= term.key %>: "<%= term.translation %>"
-<%   end
+<% else 
+    if term.key == '[init-node]' or term.key == '[end-node]'
+      node_keys << term.translation if term.key == '[init-node]'
+      node_keys.pop if term.key == '[end-node]'
+    else
+      if node_keys.length() > 0
+        key_join = node_keys.join("_")+"_"+term.key
+      else
+        key_join = term.key
+      end
+%>  <%= key_join %>: "<%= term.translation %>"
+<%  end    
   end
+end
 %>

--- a/lib/localio/templates/resx_localizable.erb
+++ b/lib/localio/templates/resx_localizable.erb
@@ -122,14 +122,26 @@
     <comment>Controls the Language and ensures that the font for all elements in the RootFrame aligns with the app's language. Set to the language code of this resource file's language.</comment>
   </data>
 <%
+node_keys = []
 @segments.each do |term|
      if term.is_comment? %>
   <!-- <%= term.translation %> -->
-<% else %>  <data name="<%= term.key %>" xml:space="preserve">
+<% else 
+ if term.key == '[init-node]' or term.key == '[end-node]'
+      node_keys << term.translation if term.key == '[init-node]'
+      node_keys.pop if term.key == '[end-node]'
+    else
+      if node_keys.length() > 0
+        key_join = node_keys.join().capitalize+term.key.capitalize
+      else
+        key_join = term.key
+      end
+%>  <data name="<%= key_join %>" xml:space="preserve">
     <value><![CDATA[<%= term.translation %>]]></value>
     <comment/>
   </data>
-<%   end
+<%  end
+   end
   end
 %>
 

--- a/lib/localio/templates/swift_constant_localizable.erb
+++ b/lib/localio/templates/swift_constant_localizable.erb
@@ -8,6 +8,19 @@ Created by localio
 
 import Foundation
 
-<% @segments.each do |term| %>
-let <%= term.key %>: String = { return NSLocalizedString("<%= term.translation %>", comment: "") }()<%
+<% 
+node_keys = []
+@segments.each do |term| 
+    if term.key == '[init-node]' or term.key == '[end-node]'
+        node_keys << term.translation if term.key == '[init-node]'
+        node_keys.pop if term.key == '[end-node]'
+    else
+        if node_keys.length() >0
+            key_join = node_keys.join("_").capitalize+"_"+term.key.downcase
+        else
+            key_join = term.key
+        end
+%>
+let kLocale<%= key_join %>: String = { return NSLocalizedString("_<%= key_join %>", comment: "") }()<%
+    end
 end %>

--- a/lib/localio/writers/ios_writer.rb
+++ b/lib/localio/writers/ios_writer.rb
@@ -25,7 +25,7 @@ class IosWriter
 
         unless term.is_comment?
           constant_key = ios_constant_formatter term.keyword
-          constant_value = key
+          constant_value = translation
           constant_segment = Segment.new(constant_key, constant_value, lang)
           constant_segments.segments << constant_segment
         end
@@ -45,11 +45,11 @@ class IosWriter
   private
 
   def self.ios_key_formatter(key)
-    '_'+key.space_to_underscore.strip_tag.capitalize
+    key.space_to_underscore.strip_tag.capitalize
   end
 
   def self.ios_constant_formatter(key)
-    'kLocale'+key.space_to_underscore.strip_tag.camel_case
+    key.space_to_underscore.strip_tag.camel_case
   end
 
 end

--- a/lib/localio/writers/swift_writer.rb
+++ b/lib/localio/writers/swift_writer.rb
@@ -25,7 +25,7 @@ class SwiftWriter
 
         unless term.is_comment?
           constant_key = swift_constant_formatter term.keyword
-          constant_value = key
+          constant_value = translation
           constant_segment = Segment.new(constant_key, constant_value, lang)
           constant_segments.segments << constant_segment
         end
@@ -44,10 +44,10 @@ class SwiftWriter
   private
 
   def self.swift_key_formatter(key)
-    '_'+key.space_to_underscore.strip_tag.capitalize
+     key.space_to_underscore.strip_tag.capitalize
   end
 
   def self.swift_constant_formatter(key)
-    'kLocale'+key.space_to_underscore.strip_tag.camel_case
+    key.space_to_underscore.strip_tag.camel_case
   end
 end


### PR DESCRIPTION
In order to satisfy the tree structure of nodes in the json files, homogeneous changes are added for all the data files
New keys are added in rows to control the start and end of the tree nodes:
![image](https://user-images.githubusercontent.com/51528759/116003036-abf16e00-a5fc-11eb-890d-ab846bcb8d54.png)


With this we can achieve that json objects comply with a correct node tree structure:
![image](https://user-images.githubusercontent.com/51528759/116003105-f115a000-a5fc-11eb-9085-32641d1fc0ce.png)

Additionally, different keys are added for the final comments. Previously, the ___comment___ skull was repeated, which generated an invalid json object:
![image](https://user-images.githubusercontent.com/51528759/116003168-2de19700-a5fd-11eb-8d59-f483b303e513.png)
